### PR TITLE
STBUG-4: Change registry from github to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
-  "name": "@seolcita/s-storybook",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/seolcita"
-  },
-  "version": "0.0.6",
+  "name": "sk-storybook",
+  "version": "0.0.2",
   "description": "A React component library",
   "scripts": {
     "rollup": "rollup -c",


### PR DESCRIPTION
## Pull Request

**Description:**

< Issue >
The auth token is correctly set in GitHub for this library. However, the 401 error still exists in GitHub action for the user using this library. 

< Solution >
Publish this library to npm.
npm package name is updated from `@seolcita/s-storybook` to `sk-storybook`
`npm i sk-storybook`
https://www.npmjs.com/package/sk-storybook


**Checklist:**

- [x] I have tested the changes locally.
- [x] I have updated the documentation.

**Screenshots (if applicable):**
- N/A

**Future Works:**
- N/A