### PR TITLE
SB-33: Separate Badge component into Badge and Chip components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sk-storybook",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "A React component library",
   "scripts": {
     "rollup": "rollup -c",

--- a/src/components/Badge/Badge.styles.tsx
+++ b/src/components/Badge/Badge.styles.tsx
@@ -4,24 +4,29 @@ import { BadgeProps } from './Badge';
 
 export interface ContainerProps {
   $bgColor: BadgeProps['bgColor'];
-  $title: BadgeProps['title'];
+  $count: BadgeProps['count'];
 }
 
-export const Container = styled.div<ContainerProps>`
-  display: inline-block;
-  border-radius: ${({ $title }) => ($title ? '1.5rem' : '50%')};
-  padding: ${({ $title }) => ($title ? '0.35rem 1.2rem' : '0.5rem')};
-  background-color: ${({ $bgColor }) =>
-    $bgColor ? ColorMap[$bgColor].main : 'black'};
+export const Container = styled.div`
   position: relative;
+`;
 
-  ${({ $title }) =>
-    !$title &&
+export const StyledBadge = styled.div<ContainerProps>`
+  display: inline-block;
+  border-radius: ${({ $count }) => ($count ? '1.5rem' : '50%')};
+  padding: ${({ $count }) => ($count ? '0.5rem 1rem' : '0.5rem')};
+  background-color: ${({ $bgColor }) =>
+    $bgColor ? ColorMap[$bgColor].main : ColorMap['primary'].main};
+  position: absolute;
+  top: -1rem;
+  right: -1rem;
+
+  ${({ $count }) =>
+    !$count &&
     css`
-      position: absolute;
-      top: -0.7rem;
-      right: -0.7rem;
-      width: 1.5rem;
-      height: 1.5rem;
+      top: -0.4rem;
+      right: -0.4rem;
+      width: 2rem;
+      height: 2rem;
     `};
 `;

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -4,11 +4,14 @@ import { cleanup, render, screen } from '@testing-library/react';
 
 import { ColorMap } from '../Color';
 import Badge, { BadgeProps } from './Badge';
+import Placeholder from '../../utils/placeholder';
 
 const props: BadgeProps = {
-  title: 'Badge Title',
+  count: 50,
+  maxCount: 55,
   bgColor: 'primary',
   color: 'white',
+  children: <Placeholder />,
 };
 
 describe('Badge', () => {
@@ -20,36 +23,43 @@ describe('Badge', () => {
     cleanup();
   });
 
-  it('renders with correct title', () => {
-    render(<Badge {...props} />);
+  it('renders without count', () => {
+    render(<Badge children={props.children} />);
 
-    const badge = screen.getByLabelText('badge');
+    const badge = screen.getByTestId('badge');
 
     expect(badge).toBeInTheDocument();
+    expect(badge).toHaveStyle('width: 2rem');
+    expect(badge).toHaveStyle('height: 2rem');
   });
 
   it('renders with correct background color', () => {
-    render(<Badge {...props} />);
+    render(<Badge {...props}>{props.children}</Badge>);
 
-    const badge = screen.getByLabelText('badge');
-
-    expect(badge).toHaveStyle(`background-color: ${ColorMap.primary.main}`);
+    expect(screen.getByTestId('badge')).toHaveStyle(
+      `background-color: ${ColorMap.primary.main}`
+    );
   });
 
-  it('renders with correct title color', () => {
-    render(<Badge {...props} />);
+  it('renders with correct count color', () => {
+    render(<Badge {...props}>{props.children}</Badge>);
 
-    const badgeTitle = screen.getByText('Badge Title');
-
-    expect(badgeTitle).toHaveStyle(`color: ${ColorMap.white.main}`);
+    expect(screen.getByText('50')).toHaveStyle(`color: ${ColorMap.white.main}`);
   });
 
-  it('renders with correct size when title is not exist', () => {
-    render(<Badge />);
+  it('renders with correct count value', () => {
+    render(<Badge {...props}>{props.children}</Badge>);
 
-    const badge = screen.getByLabelText('badge');
+    expect(screen.getByText('50')).toBeInTheDocument();
+  });
 
-    expect(badge).toHaveStyle('width: 1.5rem');
-    expect(badge).toHaveStyle('height: 1.5rem');
+  it('renders with correct count value when count is higher than maxCount', () => {
+    render(
+      <Badge {...props} maxCount={45}>
+        {props.children}
+      </Badge>
+    );
+
+    expect(screen.getByText('45')).toBeInTheDocument();
   });
 });

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,26 +1,53 @@
 import React from 'react';
 import { ReactElement } from 'react';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
 
 import { Colors } from '../Color';
 import Typography from '../Typography';
-import { Container } from './Badge.styles';
+import { Container, StyledBadge } from './Badge.styles';
+import { FlexCenter } from '../../styles/Common/Common.styles';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export interface BadgeProps {
-  title?: string | number;
+  count?: number;
+  maxCount?: number;
   color?: Colors;
   bgColor?: Colors;
+  children: React.ReactNode;
 }
 
 const Badge = ({
-  title,
+  count,
+  maxCount,
   bgColor,
   color = 'white',
+  children,
 }: BadgeProps): ReactElement => {
   return (
-    <Container $bgColor={bgColor} $title={title} aria-label='badge'>
-      <Typography variant='textXS' color={color} fontWeight='bold'>
-        {title}
-      </Typography>
+    <Container>
+      <StyledBadge $bgColor={bgColor} $count={count} data-testid='badge'>
+        {count && maxCount && count > maxCount ? (
+          <FlexCenter>
+            <Typography variant='textXS' color={color} fontWeight='bold'>
+              {maxCount}
+            </Typography>
+            <FontAwesomeIcon
+              icon={faPlus}
+              style={{
+                color: color,
+                fontSize: '0.8rem',
+              }}
+            />
+          </FlexCenter>
+        ) : (
+          count && (
+            <Typography variant='textXS' color={color} fontWeight='bold'>
+              {count < 1 ? 1 : count}
+            </Typography>
+          )
+        )}
+      </StyledBadge>
+      {children}
     </Container>
   );
 };

--- a/src/components/Chip/Chip.styles.tsx
+++ b/src/components/Chip/Chip.styles.tsx
@@ -1,0 +1,15 @@
+import styled, { css } from 'styled-components';
+import { ColorMap, Colors } from '../Color';
+
+export interface ContainerProps {
+  $bgColor: Colors;
+  $title: string;
+}
+
+export const Container = styled.div<ContainerProps>`
+  display: inline-block;
+  border-radius: 5rem;
+  padding: 0.5rem 1.75rem;
+  background-color: ${({ $bgColor }) => ColorMap[$bgColor].main};
+  position: relative;
+`;

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { ColorMap } from '../Color';
+import Badge, { ChipProps } from './Chip';
+
+const props: ChipProps = {
+  title: 'Chip Title',
+  bgColor: 'primary',
+  color: 'white',
+};
+
+describe('Chip', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders with correct title', () => {
+    render(<Badge {...props} />);
+
+    expect(screen.getByTestId('chip')).toBeInTheDocument();
+  });
+
+  it('renders with correct background color', () => {
+    render(<Badge {...props} />);
+
+    expect(screen.getByTestId('chip')).toHaveStyle(
+      `background-color: ${ColorMap.primary.main}`
+    );
+  });
+
+  it('renders with correct title color', () => {
+    render(<Badge {...props} />);
+
+    expect(screen.getByText('Chip Title')).toHaveStyle(
+      `color: ${ColorMap.white.main}`
+    );
+  });
+});

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ReactElement } from 'react';
+
+import { Colors } from '../Color';
+import Typography from '../Typography';
+import { Container } from './Chip.styles';
+
+export interface ChipProps {
+  title: string;
+  color?: Colors;
+  bgColor?: Colors;
+}
+
+const Chip = ({
+  title,
+  bgColor = 'primary',
+  color = 'white',
+}: ChipProps): ReactElement => {
+  return (
+    <Container $bgColor={bgColor} $title={title} data-testid='chip'>
+      <Typography variant='textXS' color={color} fontWeight='bold'>
+        {title}
+      </Typography>
+    </Container>
+  );
+};
+
+export default Chip;
+export { Chip };

--- a/src/components/Chip/index.ts
+++ b/src/components/Chip/index.ts
@@ -1,0 +1,3 @@
+export { default } from './Chip';
+export * from './Chip';
+export * from './Chip.styles';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export { default as Button } from './Button';
 export { default as Card } from './Card';
 export { default as Color } from './Color';
+export { default as Chip } from './Chip';
 export { default as Header } from './Header';
 export { default as ImageStepsProgressBar } from './ImageStepsProgressBar';
 export { default as Select } from './Select';

--- a/src/stories/components/Badge/Badge.mdx
+++ b/src/stories/components/Badge/Badge.mdx
@@ -13,7 +13,7 @@ The Badge component is a small, versatile element used to display numbers, statu
 
 ## Props
 
-<Controls include={['bgColor']} />
+<Controls include={['bgColor', 'count', 'maxCount']} />
 
 ## Variants
 
@@ -23,8 +23,14 @@ The Badge component is a small, versatile element used to display numbers, statu
   <Story of={BadgeStories.Default} />
 </Canvas>
 
-### Text
+### Count
 
 <Canvas>
-  <Story of={BadgeStories.Text} />
+  <Story of={BadgeStories.Count} />
+</Canvas>
+
+### Max Count
+
+<Canvas>
+  <Story of={BadgeStories.MaxCount} />
 </Canvas>

--- a/src/stories/components/Badge/Badge.stories.tsx
+++ b/src/stories/components/Badge/Badge.stories.tsx
@@ -7,35 +7,59 @@ import Badge from '../../../components/Badge';
 const meta: Meta<typeof Badge> = {
   title: 'Components/Atomic/Badge',
   component: Badge,
+  argTypes: {
+    count: {
+      control: {
+        type: 'number',
+        min: 1,
+        step: 1,
+      },
+    },
+    maxCount: {
+      control: {
+        type: 'number',
+        min: 1,
+        step: 1,
+      },
+    },
+  },
 };
 
 export default meta;
 
-function storyDecorator(): Story {
-  return {
-    decorators: [
-      (Story) => (
-        <Box
-          width={'4rem'}
-          height={'4rem'}
-          bgcolor={'lightgrey'}
-          borderRadius={'50%'}
-          position={'relative'}
-        >
-          <Story />
-        </Box>
-      ),
-    ],
-  };
-}
+const PlaceHolder = (
+  <Box
+    width={'5rem'}
+    height={'5rem'}
+    bgcolor={'lightgrey'}
+    display={'flex'}
+    justifyContent={'center'}
+    alignItems={'center'}
+    borderRadius={'50%'}
+  ></Box>
+);
 
 type Story = StoryObj<typeof Badge>;
 
 export const Default: Story = {
-  ...storyDecorator(),
-  args: { bgColor: 'primary' },
+  args: { bgColor: 'primary', children: PlaceHolder },
 };
 
-export const Text: Story = {
-  args: { title: 'Text', color: 'white', bgColor: 'primary' },
+export const Count: Story = {
+  args: {
+    count: 55,
+    color: 'white',
+    bgColor: 'primary',
+    children: PlaceHolder,
+  },
+};
+
+export const MaxCount: Story = {
+  args: {
+    count: 55,
+    maxCount: 50,
+    color: 'white',
+    bgColor: 'primary',
+    children: PlaceHolder,
+  },
 };

--- a/src/stories/components/Chip/Chip.mdx
+++ b/src/stories/components/Chip/Chip.mdx
@@ -1,0 +1,24 @@
+import { Controls, Story, Canvas, Meta } from '@storybook/addon-docs';
+import * as ChipStories from './Chip.stories.tsx';
+
+<Meta title='Components/Atomic/Chip' of={ChipStories} />
+
+## Overview
+
+Chip component is useful for presenting small pieces of information in a compact and visually distinctive way. It includes a title prop to display text and optional color and bgColor props to customize the text and background colors. The Chip component is often used to display categories, tags, or other small pieces of information. It uses the Typography component to ensure consistent text styling.
+
+<Canvas>
+  <Story of={ChipStories.Default} />
+</Canvas>
+
+## Props
+
+<Controls include={['title', 'bgColor', 'count']} />
+
+## Variants
+
+<br />
+### Default
+<Canvas>
+  <Story of={ChipStories.Default} />
+</Canvas>

--- a/src/stories/components/Chip/Chip.stories.tsx
+++ b/src/stories/components/Chip/Chip.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Chip from '../../../components/Chip';
+
+const meta: Meta<typeof Chip> = {
+  title: 'Components/Atomic/Chip',
+  component: Chip,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Chip>;
+
+export const Default: Story = {
+  args: { title: 'Chip Title', bgColor: 'primary', color: 'white' },
+};

--- a/src/stories/components/Chip/index.ts
+++ b/src/stories/components/Chip/index.ts
@@ -1,0 +1,1 @@
+export * from '.';

--- a/src/utils/placeholder.tsx
+++ b/src/utils/placeholder.tsx
@@ -16,16 +16,17 @@ export type PlaceholderProps = {
 export type StyledPlaceholderProps = {
   bgcolor: ColorVariant;
   width: PlaceholderProps['width'];
-  isFullWidth: PlaceholderProps['isFullWidth'];
+  $isFullWidth: PlaceholderProps['isFullWidth'];
   height: PlaceholderProps['height'];
-  borderRadius: PlaceholderProps['borderRadius'];
+  $borderRadius: PlaceholderProps['borderRadius'];
 };
 
 export const StyledPlaceholder = styled.div<StyledPlaceholderProps>`
   background-color: ${({ bgcolor }) => bgcolor.extraLight};
-  width: ${({ width, isFullWidth }) => (isFullWidth ? '100%' : `${width}rem`)};
+  width: ${({ width, $isFullWidth }) =>
+    $isFullWidth ? '100%' : `${width}rem`};
   height: ${({ height }) => `${height}rem`};
-  border-radius: ${({ borderRadius }) => `${borderRadius}rem`};
+  border-radius: ${({ $borderRadius }) => `${$borderRadius}rem`};
   padding: 1rem;
 `;
 
@@ -41,11 +42,11 @@ export default function Placeholder({
     <StyledPlaceholder
       bgcolor={ColorMap[color]}
       width={width}
-      isFullWidth={isFullWidth}
+      $isFullWidth={isFullWidth}
       height={height}
-      borderRadius={borderRadius}
+      $borderRadius={borderRadius}
     >
-      <Typography variant="textXS" color={color} fontWeight="semiBold">
+      <Typography variant='textXS' color={color} fontWeight='semiBold'>
         {label}
       </Typography>
     </StyledPlaceholder>


### PR DESCRIPTION
## Pull Request

**Description:**

- Separate Badge component into Badge and Chip components

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have updated the documentation.

**Screenshots (if applicable):**
< Badge >

https://github.com/Seolcita/s-storybook/assets/83251839/e364f332-980b-447a-a6aa-e8bd40e471d0


< Chip >

https://github.com/Seolcita/s-storybook/assets/83251839/ba2b4523-b7cd-4f8e-bc79-e845a414db9b


**Future Works:**
- N/A