### PR TITLE
SB-35: Deprecate Card and Create Tile

### DIFF
--- a/.changeset/early-radios-laugh.md
+++ b/.changeset/early-radios-laugh.md
@@ -1,0 +1,5 @@
+---
+"sk-storybook": patch
+---
+
+Card component shouldn't be changed. Back to original Card component.

--- a/.changeset/shiny-poets-sort.md
+++ b/.changeset/shiny-poets-sort.md
@@ -1,0 +1,5 @@
+---
+"sk-storybook": minor
+---
+
+Card component is deprecated. Previous user still can use that but not able to see it in Storybook. Tile component Added. Use this component instead of Card component.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Storybook Application
 
-This application uses [Storybook](https://storybook.js.org/) to develop, showcase, and document UI components for React with a strong focus on accessibility.
+This library uses [Storybook](https://storybook.js.org/) to develop, showcase, and document UI components for React with a strong focus on accessibility.
 Goal is to ensure that components are usable by everyone, adhering to best practices for accessibility.
 
 ## Accessibility Focus
@@ -17,10 +17,9 @@ This includes usage examples, and prop definitions in each component.
 You can view Storybook and explore components in detail at [sk-storybook app](https://sk-storybook.vercel.app/).
 <img width="1397" alt="Screen Shot 2024-02-01 at 4 53 57 PM" src="https://github.com/Seolcita/s-storybook/assets/83251839/32940ca0-6e8c-4c4b-8053-9695d6b99287">
 
-
 ## Install package
 
-Install the dependencies [sk-storybook npm](https://www.npmjs.com/package/sk-storybook)
+Install package [sk-storybook npm](https://www.npmjs.com/package/sk-storybook)
 
 ```bash
 npm install sk-storybook
@@ -38,4 +37,3 @@ please feel free to open an issue on GitHub repository [sk-storybook github](htt
 ## License
 
 This project is licensed under the ISC License
-

--- a/deprecated/Card/Card.mdx
+++ b/deprecated/Card/Card.mdx
@@ -3,6 +3,8 @@ import * as CardStories from './Card.stories.tsx';
 
 <Meta title='Components/Atomic/Card' of={CardStories} />
 
+## DEPRECATED - This component is deprecated. Use Tile component instead.
+
 ## Overview
 
 Card is container for other components.

--- a/deprecated/Card/Card.stories.tsx
+++ b/deprecated/Card/Card.stories.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Card from '../../src/components/Card';
+import Placeholder from '../../src/utils/placeholder';
+
+const meta: Meta<typeof Card> = {
+  title: 'Components/Atomic/Card',
+  component: Card,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+const placeholder = <Placeholder isFullWidth color='warning' />;
+
+export const Padded: Story = {
+  args: {
+    isInteractive: false,
+    isPadded: true,
+    tabIndex: 0,
+    ariaLabel: 'ARIA-Label',
+    width: 35,
+    margin: 'xl',
+    children: placeholder,
+  },
+};
+
+export const NonPadded: Story = {
+  args: {
+    isInteractive: false,
+    isPadded: false,
+    tabIndex: 0,
+    width: 35,
+    ariaLabel: 'ARIA-Label',
+    children: placeholder,
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    isInteractive: true,
+    isPadded: true,
+    tabIndex: 0,
+    width: 35,
+    ariaLabel: 'ARIA-Label',
+    children: placeholder,
+  },
+};
+
+export const NonInteractive: Story = {
+  args: {
+    isInteractive: false,
+    isPadded: true,
+    tabIndex: 0,
+    width: 35,
+    ariaLabel: 'ARIA-Label',
+    children: placeholder,
+  },
+};
+
+export const NoBoxShadow: Story = {
+  args: {
+    isInteractive: false,
+    isPadded: true,
+    tabIndex: 0,
+    width: 35,
+    ariaLabel: 'ARIA-Label',
+    hasBoxShadow: false,
+    children: placeholder,
+  },
+};

--- a/deprecated/Card/index.ts
+++ b/deprecated/Card/index.ts
@@ -1,0 +1,1 @@
+export * from '.';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sk-storybook",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "A React component library",
   "scripts": {
     "rollup": "rollup -c",

--- a/src/components/Tile/Tile.styles.tsx
+++ b/src/components/Tile/Tile.styles.tsx
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+import { space } from '../../tokens/space-token';
+import ColorMap from '../Color/ColorMap';
+import { TileProps } from './Tile';
+
+interface StyledCardProps {
+  $isInteractive: TileProps['isInteractive'];
+  $isPadded: TileProps['isPadded'];
+  width?: TileProps['width'];
+  height?: TileProps['height'];
+  $fullWidth?: TileProps['fullWidth'];
+  $minWidth?: TileProps['minWidth'];
+  $maxWidth?: TileProps['maxWidth'];
+  $margin?: string;
+  $hasBoxShadow: TileProps['hasBoxShadow'];
+  $borderRadius?: TileProps['borderRadius'];
+}
+
+const fixedBoxShadow = `0.3rem 0.35rem 0.5rem ${ColorMap['grey'].light}`;
+const fixedBackgroundColor = ColorMap['white'].main;
+
+export const StyledTile = styled.section<StyledCardProps>`
+  position: relative;
+  padding: ${({ $isPadded }) => ($isPadded ? space.lg : space.none)};
+  background-color: ${fixedBackgroundColor};
+  box-shadow: ${({ $hasBoxShadow }) =>
+    $hasBoxShadow ? fixedBoxShadow : 'none'};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: ${({ $borderRadius }) => $borderRadius}rem;
+  overflow: hidden;
+  margin: ${({ $margin }) => $margin};
+  cursor: ${({ $isInteractive }) => ($isInteractive ? 'pointer' : 'default')};
+  ${({ $fullWidth }) => $fullWidth && `width: 100%;`}
+  ${({ width }) => width && `width: ${width}rem;`}
+  ${({ height }) => height && `height: ${height}rem;`}
+  ${({ $minWidth }) => $minWidth && `min-width: ${$minWidth}rem;`}
+  ${({ $maxWidth }) => $maxWidth && `max-width: ${$maxWidth}rem;`}
+
+  &:hover {
+    box-shadow: ${({ $isInteractive, $hasBoxShadow }) =>
+      $hasBoxShadow
+        ? $isInteractive
+          ? `0.4rem 0.5rem 0.65rem ${ColorMap['grey'].light}`
+          : fixedBoxShadow
+        : 'none'};
+  }
+
+  &:active {
+    box-shadow: ${({ $isInteractive, $hasBoxShadow }) =>
+      $hasBoxShadow
+        ? $isInteractive
+          ? `0.3rem 0.4rem 0.4rem ${ColorMap['grey'].light}`
+          : fixedBoxShadow
+        : 'none'};
+  }
+`;

--- a/src/components/Tile/Tile.test.tsx
+++ b/src/components/Tile/Tile.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import Tile, { TileProps } from './Tile';
+
+const props: TileProps = {
+  isInteractive: false,
+  isPadded: false,
+  tabIndex: 0,
+  ariaLabel: 'test tile',
+  width: 100,
+  height: 100,
+  minWidth: 100,
+  maxWidth: 100,
+  margin: 'none',
+  hasBoxShadow: false,
+  borderRadius: 0.5,
+  children: 'Test Tile',
+};
+
+describe('Card', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders without crashing', () => {
+    render(<Tile {...props}>Test Tile</Tile>);
+    expect(screen.getByText('Test Tile')).toBeInTheDocument();
+  });
+
+  it('renders without padding', () => {
+    render(<Tile {...props}>Test Tile</Tile>);
+    expect(screen.getByText('Test Tile')).toHaveStyle('padding: 0');
+  });
+
+  it('renders without box shadow', () => {
+    render(
+      <Tile {...props} hasBoxShadow={false}>
+        Test Tile
+      </Tile>
+    );
+    expect(screen.getByText('Test Tile')).toHaveStyle('box-shadow: none');
+  });
+
+  it('renders with correct width and height', () => {
+    render(
+      <Tile {...props} width={20} height={30}>
+        Test Tile
+      </Tile>
+    );
+    expect(screen.getByText('Test Tile')).toHaveStyle('width: 20rem');
+    expect(screen.getByText('Test Tile')).toHaveStyle('height: 30rem');
+  });
+
+  it('renders with correct border radius', () => {
+    render(
+      <Tile {...props} borderRadius={5}>
+        Test Tile
+      </Tile>
+    );
+    expect(screen.getByText('Test Tile')).toHaveStyle('border-radius: 5rem');
+  });
+});

--- a/src/components/Tile/Tile.tsx
+++ b/src/components/Tile/Tile.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { ReactElement, ReactNode } from 'react';
+import { StyledTile } from './Tile.styles';
+import { setSpaceInput, setSpacing } from '../../helper/setSpacing';
+
+export interface TileProps {
+  isInteractive?: boolean;
+  isPadded?: boolean;
+  tabIndex?: number;
+  ariaLabel: string;
+  fullWidth?: boolean;
+  width?: number;
+  height?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  margin?: setSpaceInput;
+  hasBoxShadow?: boolean;
+  borderRadius?: number;
+  children?: ReactNode;
+}
+
+const Tile = ({
+  isInteractive = false,
+  isPadded = true,
+  tabIndex = 0,
+  ariaLabel,
+  width,
+  height,
+  margin,
+  hasBoxShadow = true,
+  borderRadius = 0.5,
+  minWidth,
+  maxWidth,
+  fullWidth,
+  children,
+}: TileProps): ReactElement => {
+  const formattedMargin = margin ? setSpacing(margin) : setSpacing('none');
+  return (
+    <StyledTile
+      $isInteractive={isInteractive}
+      $isPadded={isPadded}
+      tabIndex={tabIndex}
+      width={width}
+      height={height}
+      $minWidth={minWidth}
+      $maxWidth={maxWidth}
+      $fullWidth={fullWidth}
+      $margin={formattedMargin}
+      $hasBoxShadow={hasBoxShadow}
+      $borderRadius={borderRadius}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </StyledTile>
+  );
+};
+
+export { Tile };
+export default Tile;

--- a/src/components/Tile/index.ts
+++ b/src/components/Tile/index.ts
@@ -1,0 +1,3 @@
+export { default } from './Tile';
+export * from './Tile';
+export * from './Tile.styles';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,4 @@ export { default as Spinner } from './Spinner';
 export { default as Toast } from './Toast';
 export { default as Badge } from './Badge';
 export { default as Modal } from './Modal';
+export { default as Tile } from './Tile';

--- a/src/stories/components/Card/index.ts
+++ b/src/stories/components/Card/index.ts
@@ -1,1 +1,0 @@
-export * from './';

--- a/src/stories/components/Tile/Tile.mdx
+++ b/src/stories/components/Tile/Tile.mdx
@@ -1,0 +1,55 @@
+import { Controls, Story, Canvas, Meta } from '@storybook/addon-docs';
+import * as TileStories from './Tile.stories.tsx';
+
+<Meta title='Components/Atomic/Tile' of={TileStories} />
+
+## Overview
+
+Tile is container for other components.
+
+<Canvas>
+  <Story of={TileStories.Padded} />
+</Canvas>
+
+## Props
+
+<Controls include={['isInteractive', 'isPadded', 'hasBoxShadow']} />
+
+## Variants
+
+<br />
+### Padded
+
+<Canvas>
+  <Story of={TileStories.Padded} />
+</Canvas>
+
+### Not Padded
+
+<Canvas>
+  <Story of={TileStories.NonPadded} />
+</Canvas>
+
+### Interactive
+
+<Canvas>
+  <Story of={TileStories.Interactive} />
+</Canvas>
+
+### Not Interactive
+
+<Canvas>
+  <Story of={TileStories.NonInteractive} />
+</Canvas>
+
+### No BoxShadow
+
+<Canvas>
+  <Story of={TileStories.NoBoxShadow} />
+</Canvas>
+
+### Full Width
+
+<Canvas>
+  <Story of={TileStories.FullWidth} />
+</Canvas>

--- a/src/stories/components/Tile/Tile.stories.tsx
+++ b/src/stories/components/Tile/Tile.stories.tsx
@@ -1,17 +1,30 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
-import Card from '../../../components/Card';
+import Tile from '../../../components/Tile';
 import Placeholder from '../../../utils/placeholder';
+import { Box } from '@mui/material';
 
-const meta: Meta<typeof Card> = {
-  title: 'Components/Atomic/Card',
-  component: Card,
+const meta: Meta<typeof Tile> = {
+  title: 'Components/Atomic/Tile',
+  component: Tile,
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Card>;
+function storyDecorator(width: number): Story {
+  return {
+    decorators: [
+      (Story) => (
+        <Box width={`${width}rem`}>
+          <Story />
+        </Box>
+      ),
+    ],
+  };
+}
+
+type Story = StoryObj<typeof Tile>;
 
 const placeholder = <Placeholder isFullWidth color='warning' />;
 
@@ -69,5 +82,18 @@ export const NoBoxShadow: Story = {
     ariaLabel: 'ARIA-Label',
     hasBoxShadow: false,
     children: placeholder,
+  },
+};
+
+export const FullWidth: Story = {
+  ...storyDecorator(63),
+  args: {
+    isInteractive: false,
+    isPadded: true,
+    tabIndex: 0,
+    ariaLabel: 'ARIA-Label',
+    hasBoxShadow: false,
+    children: placeholder,
+    fullWidth: true,
   },
 };

--- a/src/stories/components/Tile/index.ts
+++ b/src/stories/components/Tile/index.ts
@@ -1,0 +1,1 @@
+export * from '.';

--- a/src/stories/components/index.ts
+++ b/src/stories/components/index.ts
@@ -1,5 +1,5 @@
 export * from './Button';
-export * from './Card';
+export * from '../../../deprecated/Card';
 export * from './Color';
 export * from './Header';
 export * from './ImageStepsProgressBar';


### PR DESCRIPTION
## Pull Request

**Description:**

- The current Card has a width issue. It will be a breaking change for users. I deprecate it. Previous users can still use it but new users can't see the Card component in Storybook. 
- Tile component is added. It is the same component as the Card. Just fixed the width issue.  

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have updated the documentation.
- [x] I have added tests (if applicable).

**Screenshots (if applicable):**


https://github.com/Seolcita/s-storybook/assets/83251839/4a08d1b0-dc86-45e5-9ac9-ca2e137c0189


**Future Works:**
- N/A